### PR TITLE
Improve Error Handling

### DIFF
--- a/farkos.ks
+++ b/farkos.ks
@@ -1,8 +1,16 @@
 {
+    local farkos is lex(
+        "st",st@,
+        "ev",ev@,
+        "term", term@,
+        "error", error@,
+        "debug", debug@,
+        "panic",panic@).
 
     // Add methods here that SHOULD HAVE BEEN
     // part of the standard kOS library.
 
+    // clamp(lo, hi, val): clip val to be within lo..hi inclusive range.
     global clamp is { parameter lo, hi, val.
         return max(lo, min(hi, val)).
     }.
@@ -12,73 +20,165 @@
     local path is list(home, home + "../", pack).
 
     local pending_modules is stack().
-    local module_values is lex().
+    local module_values is lex("farkos", farkos).
 
-    function module_being_imported {
-        return pending_modules:pop().
-    }.
+    // term(h,w): open the console terminal.
+    // optional parameters can be used to set the size.
+    function term {
+        parameter h is terminal:height.
+        parameter w is terminal:width.
+        set terminal:height to h.
+        set terminal:width to w.
+        if career():candoactions
+            core:doAction("open terminal", true).
+    }
 
-    function imported { parameter module_name.
-        return module_values:haskey(module_name).
-    }.
+    // error(m): Report an error.
+    // This opens a terminal, paints the message onto
+    // the hud at top-dead-center and large, and also
+    // prints it into the terminal.
+    function error { parameter m.
+        term().
+        hudtext(m,5,2,32,RED,true).
+    }
 
-    function try_copy_from_path {
-        parameter module_name.
-
-        if not homeconnection:isconnected return.
+    // pathfind(name): find name in path.
+    // returns the directory, or "" if it is not found.
+    function pathfind { parameter name.
         for folder in path {
-            local copy_from is folder + module_name.
-            if exists(copy_from) {
-                local object_folder is "0:/ksm/".
-                local object_file is object_folder+module_name+".ksm".
-                compile copy_from+".ks" to object_file.
-                copypath(object_file, "").
-                return.
+            local filepath is folder + name.
+            if exists(filepath) {
+                return folder.
             }
         }
+        error("missing from path: "+name).
+        return "".
+    }
+
+    // source(dir,name): path to source file for module found in the path.
+    function source { parameter dir, module.
+        return dir+module+".ks".
+    }
+
+    // object(dir,name): path to object file for module found in the path.
+    function object { parameter dir, name.
+        return "0:/ksm/"+name+".ksm".
+    }
+
+    // trycompile(src, obj): attempt to compile src into obj.
+    // returns true if obj is created. if it is not, an error
+    // is displayed and it returns false.
+    function trycompile { parameter src, obj.
+        deletepath(obj).
+        compile src to obj.
+        if exists(obj) return true.
+        error("compile "+src+" to "+obj+" FAILED.").
+        return false.
+    }
+
+    // trycopy(src, dst): attempt to copy src to dst.
+    // does nothing if asked to copy a file onto itself.
+    // deletes dst before starting. returns true if dst
+    // was successfully created. If it was not, shows
+    // an error message and returns false.
+    // If the source does not exist, shows an error message
+    // and returns false.
+    function trycopy { parameter src, dst.
+        if src = dst return true.
+        if exists(dst) deletepath(dst).
+        if not exists(src) { error("trycopy: no source at "+src). return false. }
+        copypath(src, dst).
+        if exists(dst) return true.
+        error("copypath "+src+" to "+dst+" FAILED.").
+        return false.
+    }
+
+    // tryupdate(name): try to obtain updated module of this name.
+    // returns true if the source was found in the archive, if the
+    // compilation was successful, and the object is successfully
+    // copied to the local volume.
+    function tryupdate { parameter name.
+        local dir is pathfind(name).
+        if dir = "" return false.
+        local src is source(dir, name).
+        //return trycopy(src, name). // uncomment this for better debugging.
+        local obj is object(dir, name).
+        return trycompile(src, obj) and trycopy(obj, name).
+    }
+
+    // tryimport(name): try to import module name from local storage.
+    // caller must assure the module is present. Returns true if the
+    // module exported a value. If not, it shows an error message
+    // and returns false.
+    function tryimport { parameter name.
+        pending_modules:push(name).
+        runpath(name).
+        if module_values:haskey(name) return true.
+        error("module did not export self: " + name).
+        return false.
+    }
+
+    // debug(e,h,w): open the terminal and pause KSP. When unpaused,
+    // wait another five seconds before returning to allow the
+    // flight engineer to interrupt the code.
+    // Required 1st parameter is a message to show with error().
+    // Optional 2nd parameter is terminal height.
+    // Optional 3rd parameter is terminal width.
+    function debug {
+        parameter e.
+        parameter h is terminal:height.
+        parameter w is terminal:width.
+
+        term(h,w).
+        farkos:error(e).
+        kuniverse:pause().
+        panic(e).
+    }
+
+    // panic(e,h,w): Display an error and reboot.
+    // Provides a brief window for engineer to interrupt.
+    // Required 1st parameter is a message to show with error().
+    // Optional 2nd parameter is terminal height.
+    // Optional 3rd parameter is terminal width.
+    function panic {
+        parameter e.
+        parameter h is terminal:height.
+        parameter w is terminal:width.
+
+        term(h,w).
+        farkos:error(e).
+        farkos:error("Rebooting in 5 seconds.").
+        wait 5.
+        REBOOT.
+    }
+
+    global import is { parameter name.
+        if module_values:haskey(name)
+            return module_values[name].
+        until tryupdate(name) { debug("import: copy failed."). }
+        until tryimport(name) { debug("import: exec failed."). }
+        return module_values[name].
     }.
 
-    function try_import_from_local {
-        parameter module_name.
-
-        if exists(module_name) {
-            pending_modules:push(module_name).
-            runpath(module_name).
-        }
+    global export is { parameter value.
+        local name is pending_modules:pop().
+        set module_values[name] to value.
     }.
 
+    // st(name): store the named file to the home archive.
+    // returns true if the copy was successful.
     function st {
-        parameter data_file.
+        parameter name.
+        return homeconnection:isconnected
+            and trycopy(name, home+name).
+    }
 
-        if homeconnection:isconnected {
-            copypath(data_file, home+data_file).
-        }
-    }.
-
+    // ev(name): log an event message.
+    // draws the message onto the HUD, top dead center, in white.
+    // Also echoes it to the console terminal, unless the optional
+    // second parameter is set to true.
     function ev {
-        parameter message.
-
-        hudtext(message,5,2,24,WHITE,true).
-    }.
-
-    global import is {
-        parameter module_name.
-
-        if imported(module_name) {
-            return module_values[module_name].
-        }
-
-        try_copy_from_path(module_name).
-        try_import_from_local(module_name).
-        return module_values[module_name].
-    }.
-
-    global export is {
-        parameter module_value.
-
-        local module_name is module_being_imported().
-        module_values:add(module_name, module_value).
-    }.
-
-    module_values:add("farkos", lex("st",st@,"ev",ev@)).
+        parameter message, echo is true.
+        hudtext(message,5,2,24,WHITE,echo).
+    }
 }

--- a/p/persist.ks
+++ b/p/persist.ks
@@ -10,42 +10,43 @@
     export(persist).
 
     local filename is "persist.json".
-
     local persisted is choose readjson(filename) if exists(filename) else lex().
 
     //    Allow modules to have data that persists across reboots.
     //    Using a value that is not SERIALIZABLE is a coding error,
     //    and may cause the kOS program to crash.
 
-    // persist:sync - store persisted data to vessel storage.
 
-    function sync {
+    function trysync {
+        deletepath(filename).
         writejson(persisted, filename).
+        return exists(filename).
+    }
+
+    // persist:sync - store persisted data to vessel storage.
+    function sync {
+        until trysync() {
+            farkos:debug("persist: unable to write " + filename).
+        }
     }
 
     // persist:put(name, value) -- put persisted value of name
 
-    function put {
-        parameter name, value.
-
+    function put { parameter name, value.
         set persisted[name] to value.
         persist:sync().
-
         return value.
     }
 
     // persist:clr(name) -- remove persisted value of name
-    function clr {
-        parameter name.
+    function clr { parameter name.
         persisted:remove(name).
         persist:sync().
     }
 
     // persist:has(name) -- determine if name has a persisted value.
 
-    function has {
-        parameter name.
-
+    function has { parameter name.
         return persisted:haskey(name).
     }
 
@@ -55,12 +56,9 @@
     // method will return zero. if the optional third parameter is put
     // to true, and no value is stored, the default will be persisted.
 
-    function get {
-        parameter name, default is 0, doset is false.
-
+    function get { parameter name, default is 0, doset is false.
         if persist:has(name) return persisted[name].
         if doset return persist:put(name, default).
         return default.
     }
-
 }

--- a/p/phases.ks
+++ b/p/phases.ks
@@ -139,7 +139,7 @@
         if NOT persist:has("t0") {
             // do a ten second countdown.
             if countdown > 0 {
-                farkos:ev("Launch in T-" + countdown).
+                farkos:ev("Launch in T-" + countdown, false).
                 set countdown to countdown - 1.
                 return 1.
             }
@@ -176,16 +176,18 @@
         return 0.1.
     }
 
+    // simple auto-stager: stage when max thrust is zero.
+    // stop when there is no liquid fuel after the current stage.
     function stager {
-        local p is persist:get("stager_period", 2, true).
-        if alt:radar < 100 return p.
+        if alt:radar<100 return 1.
+        if maxthrust>0 return 1.
+        if stage:number<1 return 0.
+        if not stage:ready return 1.
+        stage.
         local l is stage:resourceslex.
-        local tfuel is ship:LiquidFuel.
-        local sfuel is l:SolidFuel:amount.
-        local lfuel is l:LiquidFuel:amount.
-        if sfuel=0 and lfuel=0 and stage:ready stage.
-        if ship:LiquidFuel > lfuel return p.
-        return -1.
+        local tfuel is round(ship:LiquidFuel).
+        local lfuel is round(l:LiquidFuel:amount).
+        return choose 1 if tfuel>lfuel else 0.
     }
 
     function ascent {
@@ -305,7 +307,7 @@
             return 0.
         }
 
-        farkos:ev("activate RCS to continue.").
+        farkos:ev("activate RCS to continue.", false).
 
         set Cs to prograde. set Ct to 0.
         lock steering to Cs.


### PR DESCRIPTION
farkos:
- adds term, error, debug, and panic entry points
- optional argument to farkos:ev allowing "do not echo"
- reorganized around "tryfoo" and "dofoo" with error reporting

persist:
- make sure WRITEJSON actually wrote the file.

phases:
- rework STAGER to use maxthrust. Simpler. NOTE: does not work with onion, but neither did the old one. craft using onion staging must recover (and test) "setstage"
- mark several selected farkos:ev calls to not echo to terminal