### PR TITLE
Debug Rescue of Higher Orbits

### DIFF
--- a/home/Meaningfully Holistic Pickle/go.ks
+++ b/home/Meaningfully Holistic Pickle/go.ks
@@ -11,6 +11,8 @@ loadfile("visviva").
 loadfile("predict").
 loadfile("hillclimb").
 loadfile("maneuver").
+loadfile("intercept").
+loadfile("rendezvous").
 loadfile("debug").
 //
 local pi is constant:pi.
@@ -25,10 +27,11 @@ persist_get("launch_altitude", {        // somewhat above or below the mission t
     // we do not need to really be above or below the whole orbit, but
     // we do need to have a sufficiently different orbital period.
     local mission_sma is (mission_orbit:periapsis + mission_orbit:apoapsis) / 2.
-    if mission_sma:apoapsis < 180000 return 250000.
-    else return 120000. }, true).
+    if mission_sma < 180000 return 250000.
+    else return 80000. }, true).
 //
 mission_bg(bg_stager@).                 // Start the auto-stager running in the background.
+mission_bg(bg_rcs@).                    // Start the auto-RCS-enable running in the background.
 //
 function mission_abort {
     parameter m.
@@ -36,182 +39,6 @@ function mission_abort {
     say("ABORT MISSION.").
     abort on.
     return 0. }
-//
-function plan_xfer {    // construct initial transfer maneuver
-    if abort return 0.
-    lock throttle to 0.
-    lock steering to facing.
-    if not hastarget set target to mission_target.
-
-    persist_put("phase_plan_xfer", mission_phase()).
-
-    // plan an intercept to the mission target.
-    // (persists the xfer_*_time values)
-    plan_intercept(mission_target).
-    //
-    return 0. }
-
-function plan_corr {    // plan a mid-course correction.
-    if abort return 0.
-    lock throttle to 0.
-    lock steering to facing.
-    if not hastarget set target to mission_target.
-
-    return plan_correction(mission_target). }
-
-// hang out in this phase until we are near
-function wait_near {
-    if abort return 0.
-    if kuniverse:timewarp:rate>1 return 1.                      // timewarp active, come back later.
-    if not kuniverse:timewarp:issettled return 1/10.            // if timewarp rate is changing, try again very shortly.
-    if not hastarget set target to mission_target.
-
-    lock throttle to 0.
-    lock steering to retrograde.
-
-    local Tf is persist_get("xfer_final_time").
-    local stop_warp_at is Tf - 30.
-    local wait_for is stop_warp_at - time:seconds.
-
-    // print "wait_for = "+wait_for.
-
-    if wait_for<=0 return 0.
-    if wait_for<30 return wait_for.
-    wait 3.
-    warpto(stop_warp_at).
-    return wait_for. }
-
-function approach {
-    if abort return 0.
-    if kuniverse:timewarp:rate>1 return 1.                      // timewarp active, come back later.
-    if not kuniverse:timewarp:issettled return 1/10.            // if timewarp rate is changing, try again very shortly.
-    if not hastarget set target to mission_target.
-
-    lock steering to retrograde.
-
-    // pv("","").
-    local dir is prograde:vector.                               // pv("dir", dir).
-
-    local t_p is target:position.                               // pv("t_p", t_p).
-    local t_v is target:velocity:orbit.                         // pv("t_v", t_v).
-    local s_v is ship:velocity:orbit.                           // pv("s_v", s_v).
-
-    // bias the result by 20m so we stop short of hitting the target,
-    // if we happen to be that well lined up.
-    local d is vdot(t_p, dir) - 20.                             // pv("d", d).
-    local v is vdot(s_v - t_v, dir).                            // pv("v", v).
-
-    {   // Plan to burn at a constant acceleration A, such that
-        // the burn reduces our position and velocity to zero at some
-        // future time T=0. Solve for that acceleration A and
-        // for the T for right now which will be negaitive.
-        //     V = A T                   X = A T^2 / 2
-        // Solve for time by eliminating A from the X equation:
-        //     A = V / T                 X = (V/T) T^2 2 = V T/2
-        //     T = 2 X / V
-        // Compute T, then compute A as seen above.
-    }
-    local p_dist is d.                                          // pv("p_dist", p_dist).
-    local p_rate is v.                                          // pv("p_rate", p_rate).
-
-    // computed time until X=0 V=0 at constant A
-    // NOTE: once things are nearly linear, and
-    // until we start thrusting, b_time will go down
-    // twice as fast as time is progressing.
-
-    local b_time is 2*p_dist/p_rate.                            // pv("b_time", b_time).
-
-    if b_time < 0 {
-        // print "target is behind us.".
-        set throttle to 0.
-        return 0. }
-
-    // b_accel: the required acceleration
-    local b_accel is p_rate/b_time.                             // pv("b_accel", b_accel).
-
-    // b_force: the required force
-    local b_force is b_accel*ship:mass.                         // pv("b_force", b_force).
-
-    // desired throttle command
-    local b_throt is b_force/availablethrust.                   // pv("b_throt", b_throt).
-
-    if throttle>0 or b_throt>0.5
-        set throttle to b_throt.
-
-    if throttle=0 and b_throt<0.2
-        return 1.
-
-    return 1/100. }
-
-local holding_for_rescue is false.
-function rescue {
-    if abort {
-        lock steering to retrograde.
-        lock throttle to 0.
-        // wait 1.
-        // say(LIST("Home Again,","Home Again,","Jiggity-Jig.")).
-        wait 3.
-        return 0. }
-    if kuniverse:timewarp:rate>1 return 1.                      // timewarp active, come back later.
-    if not kuniverse:timewarp:issettled return 1/10.            // if timewarp rate is changing, try again very shortly.
-    if not hastarget set target to mission_target.
-
-    local k_t is 2.                     // TODO make tunable, find good value.
-    local max_facing_error is 15.        // TODO make tunable, find good value.
-
-    // pv("","").
-    local s_p is -body:position.                                // pv("s_p", s_p).
-    local t_p is target:position.                               // pv("t_p", t_p).
-    local t_v is target:velocity:orbit.                         // pv("t_v", t_v).
-    local s_v is ship:velocity:orbit.                           // pv("s_v", s_v).
-    local r_v is t_v - s_v.                                     // pv(_v", r_v).
-
-    // if we are already in the rescue pose,
-    // do not change pose unless we are more than 100m
-    // from the target or our relative velocity
-    // exceeds 1.0 m/s.
-
-    if holding_for_rescue {
-        if t_p:mag < 100 and r_v:mag < 1.0 {
-            lock steering to lookdirup(body:north:vector, -s_p:normalized).
-            lock throttle to 0.
-            say("Activate ABORT to return home.", false).
-            return 5. }
-        set holding_for_rescue to false. }
-
-    // if we are within 20m of the target and our
-    // speed is within 0.01 m/s of the target, then
-    // enter the rescule pose.
-    if t_p:mag < 20 and r_v:mag < 0.01 {
-        set holding_for_rescue to true.
-        lock steering to lookdirup(body:north:vector, -s_p:normalized).
-        lock throttle to 0.
-        return 1. }
-
-    // if more than 15 m from the target,
-    // match a velocity toward the target
-    // of 1 m/s per 15 m of distance.
-
-    if t_p:mag > 15
-        set r_v to r_v + t_p/15.
-
-    set steering to lookdirup(r_v, facing:topvector).
-
-    local desired_delta_v to r_v:mag.                           // pv("desired_delta_v", desired_delta_v).
-    if desired_delta_v < 0.01 { set throttle to 0. return 1. }
-    local desired_accel to desired_delta_v * 2.                 // pv("desired_accel", desired_accel).
-    local desired_force is ship:mass * desired_accel.           // pv("desired_force", desired_force).
-    local desired_throttle is desired_force / availablethrust.  // pv("desired_throttle", desired_throttle).
-    local clamped_throttle is clamp(0,1,desired_throttle).      // pv("clamped_throttle", clamped_throttle).
-
-    local facing_error is vang(facing:vector,steering:vector).  // pv("facing_error", facing_error).
-    local fefac is facing_error/max_facing_error.               // pv("fefac", fefac).
-    local facing_error_factor is clamp(0,1,1-fefac).            // pv("facing_error_factor", facing_error_factor).
-
-    set throttle to clamp(0,1,facing_error_factor*clamped_throttle).
-
-    return 1/100. }
-
 //
 // Mission Plan
 //
@@ -226,24 +53,26 @@ mission_add(LIST(
     // In READY orbit.
     //
     { set mapview to true. },
-    "MATCH_INCL",   phase_match_incl@,  // match inclination of rescue target
-    "PLAN_XFER",    plan_xfer@,         // create maneuver node for starting transfer.
+    //
+    // REALIZATION: since we are launching with azimuth set to
+    // the target inclination, we end up close enough to the target
+    // orbital plane that our correction burn can fix any remaining
+    // inclination problems.
+    //
+    // "MATCH_INCL",   phase_match_incl@,  // match inclination of rescue target
+    "PLAN_XFER",    plan_intercept@,         // create maneuver node for starting transfer.
     "EXEC_XFER",    maneuver:step@,     // execute the maneuver to inject into the transfer orbit.
-    "PLAN_CORR",    plan_corr@,         // plan mid-transfer correction
+    "PLAN_CORR",    plan_correction@,         // plan mid-transfer correction
     "EXEC_CORR",    maneuver:step@,     // execute the mid-transfer correction.
     { set mapview to false. },
-    "WAIT_NEAR",    wait_near@,         // wait (or warp) until time to rendezvous
-    "APPROACH",     approach@,          // come to a stop near the target
-    "RESCUE",       rescue@,            // maintain position near target
+    "APPROACH",     coarse_approach@,          // come to a stop near the target
+    "RESCUE",       fine_approach@,            // maintain position near target
     //
     // Normal deorbit, descent, and landing process.
     //
     { abort off. return 0. },
     "DEORBIT",      phase_deorbit@,     // until our periapsis is low enough, burn retrograde.
-    { if altitude>body:atm:height { wait 3. set warp to 3. } return 0. },
-    { if altitude>body:atm:height return 1. },
-    { wait 3. set warp to 3. return 0. },
-    "FALL",         phase_fall@,        // fall to half of the atmosphere height.
+    "AERO",         phase_aero@,        // fall to half of the atmosphere height.
     "DECEL",        phase_decel@,       // decelerate to 1/4th of atmosphere height.
     "PSAFE",        phase_psafe@,       // fall until safe for parachutes
     { wait 3. set warp to 0. return 0. },

--- a/lib/maneuver.ks
+++ b/lib/maneuver.ks
@@ -42,6 +42,9 @@
     local n is nextnode.
     local v is n:burnvector.
 
+    // hold on, why has my mnv_step_s come up as
+    // not being the right direction by far?
+
     if 0=mnv_step_t                     set mnv_step_t to time:seconds + n:eta - mnv_time(v:mag)/2.
     if 0=mnv_step_s:mag                 set mnv_step_s to v:normalized.
 
@@ -66,6 +69,7 @@
       return sqrt(dt). }.                       lock throttle to th().
 
     local wt is mnv_step_t - time:seconds.
+    if wt>10                    set mnv_step_s to v:normalized.
     if wt>0 and wt<2            return wt.
     if wt>60                    warpto(time:seconds + wt - 30).
     return 1.

--- a/lib/match.ks
+++ b/lib/match.ks
@@ -44,6 +44,10 @@ function phase_match_lan {
     local match_lan is persist_get("match_lan", 0).
     local match_lon_lead is persist_get("match_lon_lead", 1).
 
+    // if the inclination is less than a degree, we do not need
+    // to do a PAD-HOLD to get in-plane.
+    if abs(inc)<1.0 return 0.
+
     if kuniverse:timewarp:rate > 1 return 1.
     if not kuniverse:timewarp:issettled return 1.
 

--- a/lib/rendezvous.ks
+++ b/lib/rendezvous.ks
@@ -1,23 +1,30 @@
+
 function coarse_approach { parameter targ is target.
+    if abort return 0.
 
     // If we are in timewarp, come back later.
     if kuniverse:timewarp:rate>1 return 1.                      // timewarp active, come back later.
     if not kuniverse:timewarp:issettled return 1/10.            // if timewarp rate is changing, try again very shortly.
 
     // See if we are in the "fast approaching" phase.
-    // This lasts until 30 seconds before xfer_final_time
+    // This lasts until (margin) seconds before xfer_final_time
     // which should be our nearest approch time.
+    //
+    // TODO: work out a decent lead time based on our
+    // expected relative velocity when we arrive.
+    //
+    // OBSERVED: arriving early ...???
+
     local Tf is persist_get("xfer_final_time").
-    local stop_warp_at is Tf - 30.
+    local stop_warp_at is Tf - 60.
     local wait_for is stop_warp_at - time:seconds.
 
-    // long in advance:
+   // use warpto if it is more than 30 sec from now:
     if wait_for>30 {
+        set throttle to 0.
         wait 3.
         warpto(stop_warp_at).
     }
-
-    lock steering to retrograde.
 
     if wait_for>0 {
         set throttle to 0.
@@ -25,6 +32,22 @@ function coarse_approach { parameter targ is target.
     }
 
     // Coarse Approach Maneuver
+    //
+    // Consider a local coordinate system with
+    // a zero plane perpendicular to our prograde
+    // velocity, which passes through the target.
+    //
+    // Thrust to bring our velocity relative to that
+    // plane to zero when at (margin) meters before
+    // intersecting the plane.
+    //
+    // Stopping Distance formula:
+    //      X = V^2 / 2 A
+    // Pick an acceleration. Work out the distance,
+    // and set the throttle (or not) based on X and
+    // our current distance.
+
+    local margin is 20.
 
     local dir is prograde:vector.                               // pv("dir", dir).
 
@@ -32,50 +55,71 @@ function coarse_approach { parameter targ is target.
     local t_v is target:velocity:orbit.                         // pv("t_v", t_v).
     local s_v is ship:velocity:orbit.                           // pv("s_v", s_v).
 
-    local Xc is vdot(t_p, dir) - 20.                             // pv("Xc", Xc).
-    local Vc is vdot(s_v - t_v, dir).                            // pv("Vc", Vc).
+    // if we descended, ship are overtaking. Xc and Vc are positive.
+    // if we ascended, target is overtaking. Xc and Vc are negative.
 
-    local Xc is Xc.                                          // pv("Xc", Xc).
-    local Vc is Vc.                                          // pv("Vc", Vc).
+    local Xc is vdot(t_p, dir).                     // pv("Xc", xc). // distance available to stop
+    local Vc is vdot(s_v - t_v, dir).               // pv("Vc", Vc). // speed toward the stopping point
 
-    local Tc is 2*Xc/Vc.                            // pv("Tc", Tc).
+    if Xc > 0 {
+        lock steering to retrograde.
+    } else {
+        set Xc to -Xc.      // pv("Xc", xc).
+        set Vc to -Vc.      // pv("Vc", Vc).
+        lock steering to prograde.
+    }
+    set Xc to Xc - margin.  // pv("Vc", Vc).
 
-    if Tc < 0 {
+    if Vc < 0 or Xc<0 {
         set throttle to 0.
-        return 0. }
+        return 0.
+    }
 
-    // A: the required acceleration
-    local A is Vc/Tc.                             // pv("A", A).
+    local A is availablethrust / ship:mass.         // pv("A", A). // available acceleration
+    local X is Vc^2 / (2*A).                        // pv("X", X). // minimum stopping distance.
 
-    // F: the required force
-    local F is A*ship:mass.                         // pv("F", F).
+    if Xc < X {
+        return 0.        // we overshot.
+    }
 
-    // desired throttle command
-    local thr is F/availablethrust.                   // pv("thr", thr).
+    local Xr is X / Xc. // pv("Xr", Xr).
+    if throttle=0 {
+        if Xr<0.90 {
+            // wait until we are closer.
+            set throttle to 0.
+            return 1/100.
+        }
+    }
 
-    if throttle>0 or thr>0.5
-        set throttle to thr.
+    if Xr < 0.01 {
+        set throttle to 0.
+        return 0.
+    }
 
-    if throttle=0 and thr<0.2
-        return 1.
-
+    set throttle to clamp(0,1,Xr).
     return 1/100. }
 
 local holding_position is false.
 function fine_approach { parameter targ is target.
-
+    if abort return 0.
     if kuniverse:timewarp:rate>1 return 1.                      // timewarp active, come back later.
     if not kuniverse:timewarp:issettled return 1/10.            // if timewarp rate is changing, try again very shortly.
 
     local k_t is 2.                     // TODO make tunable, find good value.
     local max_facing_error is 15.        // TODO make tunable, find good value.
 
-    // pv("","").
-    local s_p is -body:position.                                // pv("s_p", s_p).
+    // t_p: vector from ship to target
     local t_p is target:position.                               // pv("t_p", t_p).
+
+    // d_p: distance from ship to target.
+    local d_p is t_p:mag.                                   // pv(_v", r_v).
+
+    // t_v: Body-relative target velocity
     local t_v is target:velocity:orbit.                         // pv("t_v", t_v).
+    // s_v: Body-relative ship velocity
     local s_v is ship:velocity:orbit.                           // pv("s_v", s_v).
-    local r_v is t_v - s_v.                                     // pv(_v", r_v).
+    // r_v: Velocity of Target relative to Ship.
+    local r_v is t_v - s_v.
 
     // if we are already in the rescue pose,
     // do not change pose unless we are more than 100m
@@ -83,8 +127,8 @@ function fine_approach { parameter targ is target.
     // exceeds 1.0 m/s.
 
     if holding_position {
-        if t_p:mag < 100 and r_v:mag < 1.0 {
-            lock steering to lookdirup(body:north:vector, -s_p:normalized).
+        if d_p < 100 and r_v:mag < 1.0 {
+            phase_pose().
             lock throttle to 0.
             return 5. }
         set holding_position to false. }
@@ -92,18 +136,34 @@ function fine_approach { parameter targ is target.
     // if we are within 20m of the target and our
     // speed is within 0.01 m/s of the target, then
     // enter the rescule pose.
-    if t_p:mag < 20 and r_v:mag < 0.01 {
+    if d_p < 20 and r_v:mag < 0.01 {
         set holding_position to true.
-        lock steering to lookdirup(body:north:vector, -s_p:normalized).
+        phase_pose().
         lock throttle to 0.
         return 1. }
 
-    // if more than 15 m from the target,
-    // match a velocity toward the target
-    // of 1 m/s per 15 m of distance.
+    if d_p > 15 {
 
-    if t_p:mag > 15
-        set r_v to r_v + t_p/15.
+        // if more than 15 m from the target,
+        // command an appropriate closing velocity.
+        //      V = A T
+        //      X = 1/2 A T^2
+        // Known: X, A
+        // Compute: desired V
+        //      X = 1/2 A T^2
+        //      2 X = A T^2
+        //      2 X/A = T^2
+        //      sqrt(2 X / A) = T
+        //      V = A T
+        //        = A sqrt(2 X / A)
+        //        = sqrt(A^2 2 X / A)
+        //        = sqrt(2 X A)
+
+        local X is d_p - 10.
+        local A is availablethrust * 0.1 / ship:mass.
+        local V is sqrt(2*A*X).
+        set r_v to r_v + t_p:normalized*V.
+    }
 
     set steering to lookdirup(r_v, facing:topvector).
 

--- a/lib/task.ks
+++ b/lib/task.ks
@@ -14,10 +14,9 @@
 // return value from step controls how long we delay
 // before running the next task code.
 
-local task_gui is gui(500).
+local task_gui is gui(0,0).
 local task_panel is task_gui:addvlayout().
 local task_list is list().
-local task_gui_showing is false.
 
 function new_task {
     parameter text, cond, start, step, stop.
@@ -25,15 +24,9 @@ function new_task {
         "start", start, "step", step, "stop", stop).
 }
 
-global ret_v is { parameter v. return v. }.
-global ret_t is ret_v:bind(true).
-global ret_0 is ret_v:bind(0).
-global ret_1 is ret_v:bind(1).
-global noop is { }.
-
-local idle_task is new_task("Idle", ret_t, noop, phase_pose@, noop).
-idle_task:add("pressed", ret_t).
-idle_task:add("unpress", noop).
+local idle_task is new_task("Idle", { return true. }, { }, { return phase_pose(). }, { }).
+idle_task:add("pressed", { return true. }).
+idle_task:add("unpress", { }).
 
 local curr_task is idle_task.
 
@@ -47,12 +40,9 @@ function add_task {
 }
 
 function task_pick {
-    for t in task_list {
-        if t:pressed() {
-            if t:cond() return t.
-            t:unpress().
-        }
-    }
+    for t in task_list
+        if t:pressed() and t:cond()
+            return t.
     return idle_task.
 }
 


### PR DESCRIPTION
The first rescue mission that had a high orbit uncovered several
issues in the rescue scripting, and in the vessel configuration.

First, the Approach script zwooped us right past the target, and
we had to depend on the error controller in Rescue to make our
way back from far far away. Second, the gain was too high, and
Rescue came in too hot, resulting in overshooting. Finally, when
returning from far orbits, just diving right down to low atmosphere
resulted in bits melting off of our lander.

This drove a number of corrections (and refactorings).

- refactor PICKLE go-script to use globalized phases
- debug rendezvous code to allow prograde burns
- add PHASE_AERO to do better aerobraking
- maneuver:step could end up with the wrong burn direction
- phase_match_lan does not need to wait for low inclination orbits