### PR TITLE
Brace adjust for VS Code "folding"

### DIFF
--- a/pkg/ctrl.ks
+++ b/pkg/ctrl.ks
@@ -1,6 +1,5 @@
 @LAZYGLOBAL off.
-{
-    parameter ctrl is lex().    // augmented control package
+{   parameter ctrl is lex().    // augmented control package
 
     local phase is import("phase").
     local io is import("io").
@@ -10,7 +9,7 @@
     ctrl:add("emin", 1).    // if facing within this angle, use computed throttle
     ctrl:add("emax", 15).   // if facing outside this angle, use zero throttle
 
-    ctrl:add("pose", {
+    ctrl:add("pose", {                  // establish an idle pose
         if altitude>body:atm:height
             return lookdirup(vcrs(ship:velocity:orbit, -body:position), -body:position).
         if verticalspeed>10
@@ -47,7 +46,7 @@
         local df is (facing_error-ctrl:emin) / (ctrl:emax-ctrl:emin).
         return round(df*desired_throttle,4). }).
 
-    ctrl:add("dv", { parameter dv_fd.
+    ctrl:add("dv", { parameter dv_fd.   // dv based throttle & steering
         parameter gain is ctrl:gain.
         parameter emin is ctrl:emin.
         parameter emax is ctrl:emacs.
@@ -59,8 +58,7 @@
         lock throttle to ctrl:throttle(dv_fd).
         wait 0. }).
 
-    // cancel CTRL-mediated RCS translation.
-    ctrl:add("rcs_off", {
+    ctrl:add("rcs_off", {               // cancel CTRL-mediated RCS translation.
         io:say("CTRL: terminating RCS translation.").
         set ship:control:neutralize to true.
         set phase:force_rcs_on to 0.
@@ -69,14 +67,7 @@
         return 0. }).
 
     ctrl:add("rcs_dv_gain", 1/2).
-
-    // establish the delegate that will drive our delta-v based translation.
-    // this uses LOCK STEERING to trigger the computations, and returns the
-    // desired stable facing.
-    //
-    // To cancel this, please call ctrl:rcs_off.
-
-    ctrl:add("rcs_dv", { parameter dv_fd.  // delegate returning desired delta-v
+    ctrl:add("rcs_dv", { parameter dv_fd.  // DV based RCS control
 
         local rcs_list is list().
         local it is 0.
@@ -139,8 +130,7 @@
         return 0. }).
 
     ctrl:add("rcs_dx_speed_limit", 2).
-
-    ctrl:add("rcs_dx", { parameter dx_df.
+    ctrl:add("rcs_dx", { parameter dx_df.   // DX based RCS control
         return ctrl:rcs_dv({
             if not hastarget return V(0,0,0).
             local dx is eval(dx_df).

--- a/pkg/dbg.ks
+++ b/pkg/dbg.ks
@@ -6,6 +6,7 @@
         parameter h is terminal:height.
         set terminal:height to h.
         set terminal:width to w.
+
         // TERMINAL:WIDTH               terminal width in characters
         // TERMINAL:HEIGHT              terminal height in characters
         // TERMINAL:REVERSE             swap foreground and background colors
@@ -22,7 +23,7 @@
         if career():candoactions
             core:doAction("open terminal", true). }).
 
-    local pr_d is lex(
+    local pr_d is lex(      // map typename to formatter
         "Boolean",      { parameter value.
             return choose "TRUE" if value else "FALSE". },
         "String",       { parameter value.
@@ -56,4 +57,5 @@
         return "<"+value:typename+"> "+value:tostring. }).
 
     dbg:add("pv", { parameter name, value.      // print name and representation of value
-        print name+": "+dbg:pr(value). }). }
+        print name+": "+dbg:pr(value). }).
+}

--- a/pkg/go.ks
+++ b/pkg/go.ks
@@ -6,4 +6,5 @@
         io:say(LIST(
             "No 'GO' package found",
             "for "+ship:name+",",
-            "releasing control.")). }). }
+            "releasing control.")). }).
+}

--- a/pkg/hill.ks
+++ b/pkg/hill.ks
@@ -60,4 +60,5 @@
                 local decrement is data:copy.
                 set decrement[i] to decrement[i] - step_size.
                 results:add(decrement). } }
-        return results.}). }
+        return results.}).
+}

--- a/pkg/hover.ks
+++ b/pkg/hover.ks
@@ -1,8 +1,7 @@
 @LAZYGLOBAL off.
-{
-    parameter hover is lex(). // HOVER package
-    local radar is import("radar").
+{   parameter hover is lex(). // HOVER package
 
+    local radar is import("radar").
     local dbg is import("dbg").
 
     hover:add("hold", {                 // HOVER:HOLD(h_set,v_set): hover controller
@@ -73,18 +72,17 @@
                 // upward at a_nom m/s^2 bringing V to 0 at Hobs=Hset.
                 local h_dist is h_obs - h_set.                      // how far we are above set point
                 local v_sub is sqrt(2*a_nom*h_dist).                // additional descent speed
-                set v_cmd to v_cmd - v_sub.                         // net ascent speed
+                set v_cmd to v_cmd - v_sub. }                       // net ascent speed
 
-            } else {                // close above the set point
+            else {                // close above the set point
 
                 // vessel above set point by 10m or less.
                 // proportional control where the control at 10m error
                 // matches the control above.
                 local v_sub_10m is sqrt(2*a_nom*10).
-                set v_cmd to v_cmd - v_sub_10m*(h_obs-h_set)/10.
+                set v_cmd to v_cmd - v_sub_10m*(h_obs-h_set)/10. } }
 
-            }
-        } else if h_obs < h_set {   // below the set point
+        else if h_obs < h_set {   // below the set point
             if h_obs < h_set-10 {   // far below the set point
 
                 // vessel more than 10m below the set point.
@@ -92,18 +90,15 @@
                 // downward due to gravity, bringing V to 0 at Hobs=Hset.
                 local h_dist is h_set - h_obs.                      // how far we are above set point
                 local v_add is sqrt(2*g*h_dist).                    // abs(speed) for that acceleration
-                set v_cmd to v_cmd + v_add.                         // net ascent speed
+                set v_cmd to v_cmd + v_add. }                       // net ascent speed
 
-            } else {                // close below the set point
+            else {                // close below the set point
 
                 // vessel below set point by 10m or less.
                 // proportional control where the control at 10m error
                 // matches the control above.
                 local v_add_10m is sqrt(2*g*10).
-                set v_cmd to v_cmd + v_add_10m*(h_set-h_obs)/10.
-
-            }
-        }
+                set v_cmd to v_cmd + v_add_10m*(h_set-h_obs)/10. } }
 
         local v_obs is verticalspeed.                           // current ascent speed
         local v_err is v_cmd - v_obs.                           // positive is descending too fast.
@@ -112,4 +107,5 @@
         local a_cnet is a_cmd + g.                              // net acceleration from throttle
         local t_cmd is a_cnet / a_net.                          // throttle setting 0..1
 
-        return t_cmd. }). }
+        return t_cmd. }).
+}

--- a/pkg/io.ks
+++ b/pkg/io.ks
@@ -6,4 +6,5 @@
         // replacement implementaton for std:say(m,e).
         parameter m, e is true.
         if m:istype("List") for s in m io:say(s, e).
-        else hudtext(m,5,2,24,WHITE,e). }). }
+        else hudtext(m,5,2,24,WHITE,e). }).
+}

--- a/pkg/lamb.ks
+++ b/pkg/lamb.ks
@@ -1,7 +1,5 @@
 @LAZYGLOBAL off.
-
-{
-    parameter lamb is lex(). // lambert solver wrappers
+{   parameter lamb is lex(). // lambert solver wrappers
 
     local predict is import("predict").
     local scan is import("scan").
@@ -297,8 +295,7 @@
         if ts:hour>0 bits:add(ts:hour+"h").
         if ts:minute>0 bits:add(ts:minute+"m").
         if ts:second>0 or bits:length<1 bits:add(ts:second+"s").
-        return bits:join(" ").
-    }
+        return bits:join(" "). }
 
     lamb:add("plan_corr", {
 
@@ -445,7 +442,6 @@
         io:say("Lambert Correction predicted error: "+round((rt-rs):mag,3)+" m.").
 
         mnv:schedule_dv_at_t(result:b2, t2).
-        return 0.
-    }).
+        return 0. }).
 
 }

--- a/pkg/lambert.ks
+++ b/pkg/lambert.ks
@@ -1,6 +1,5 @@
 @LAZYGLOBAL off.
-{
-    parameter lambert is lex(). // lambert equation solver.
+{   parameter lambert is lex(). // lambert equation solver.
 
     // the content below was imported from
     // https://raw.githubusercontent.com/maneatingape/rsvp/main/src/lambert.ks
@@ -15,7 +14,8 @@
     // what finally found it for me. Many thanks!
     //
     // NOTE: I have added some comments to the code to help me follow why
-    // it is doing what it is doing.
+    // it is doing what it is doing. I have also adjusted some style points
+    // to make this behave within the VS Code "folding" mechanism.
     //
     //
     // This code is a Kerboscript port of the PyKep project Lambert's problem solver,
@@ -82,8 +82,7 @@
         if flip_direction {
             set it1 to -it1.
             set it2 to -it2.
-            set lambda to -lambda.
-        }
+            set lambda to -lambda. }
 
         // The clever part of this algorithm is reducing the problem down to a
         // function of a single variable "x" (the Lancaster-Blanchard variable).
@@ -107,8 +106,7 @@
         local v1 is (gamma / m1) * (vr1 * ir1 + vt * it1).
         local v2 is (gamma / m2) * (vr2 * ir2 + vt * it2).
 
-        return lex("v1", v1, "v2", v2).
-    }).
+        return lex("v1", v1, "v2", v2). }).
 
     // Helper function to run iterative root finding algorithms.
     local function iterative_root_finder {
@@ -121,11 +119,9 @@
         until abs(delta) < 0.00001 or iterations = 15 {
             set delta to householders_method(lambda, t, x).
             set x to x - delta.
-            set iterations to iterations + 1.
-        }
+            set iterations to iterations + 1. }
 
-        return x.
-    }
+        return x. }
 
     // The formulas for the initial guess of "x" are so accurate that on average
     // only 2 to 3 iterations of Householder's method are needed to converge.
@@ -136,13 +132,11 @@
         local t1 is (2 / 3) * (1 - lambda ^ 3).
 
         if t >= t0 {
-            return (t0 / t) ^ (2 / 3) - 1.
-        } else if t <= t1 {
-            return (5 * t1 * (t1 - t)) / (2 * t * (1 - lambda ^ 5)) + 1.
-        } else {
-            return (t0 / t) ^ (ln(t1 / t0) / ln(2)) - 1.
-        }
-    }
+            return (t0 / t) ^ (2 / 3) - 1. }
+        else if t <= t1 {
+            return (5 * t1 * (t1 - t)) / (2 * t * (1 - lambda ^ 5)) + 1. }
+        else {
+            return (t0 / t) ^ (ln(t1 / t0) / ln(2)) - 1. } }
 
     // 3rd order Householder's method. For some context the method of order 1 is the
     // well known Newton's method and the method of order 2 is Halley's method.
@@ -158,8 +152,7 @@
         local ddt is (3 * tau + 5 * x * dt + 2 * (1 - lambda ^ 2) * (lambda ^ 3) / (y ^ 3)) / a.
         local dddt is (7 * x * ddt + 8 * dt - 6 * (1 - lambda ^ 2) * (lambda ^ 5) * x / (y ^ 5)) / a.
 
-        return delta * (dt ^ 2 - delta * ddt / 2) / (dt * (dt ^ 2 - delta * ddt) + (dddt * delta ^ 2) / 6).
-    }
+        return delta * (dt ^ 2 - delta * ddt / 2) / (dt * (dt ^ 2 - delta * ddt) + (dddt * delta ^ 2) / 6). }
 
     // Calculate the time of flight using Lancaster's formula.
     local function time_of_flight {
@@ -175,6 +168,6 @@
         // guard in this case to prevent errors when taking the log of this value.
         local psi is choose constant:degtorad * arccos(g) if a > 0 else ln(max(1e-300, f + g)).
 
-        return (psi / b - x + lambda * y) / a.
-    }
+        return (psi / b - x + lambda * y) / a. }
+
 }

--- a/pkg/match.ks
+++ b/pkg/match.ks
@@ -153,8 +153,7 @@
 
             if next_Ct>0.1 and wr>1 {
                 kuniverse:timewarp:cancelwarp().
-                return 1/10. }
-        }
+                return 1/10. } }
 
         // TODO: refactor to use CTRL package.
 
@@ -164,8 +163,8 @@
         if match_throttle_prev=0 {
             lock throttle to 0.
             if next_ct<0.1 return 1.
-            if next_ct<0.4 return 1/100.
-        }
+            if next_ct<0.4 return 1/100. }
+
         set match_throttle_prev to next_Ct.
 
         local facing_error is vang(facing:vector,steering:vector).
@@ -218,7 +217,7 @@
         lock steering to prograde.
         lock throttle to _throttle().
 
-        return 5.}).
+        return 5. }).
 
     match:add("plan_xfer", {        // build MANEUVER to enter Hohmann toward Targ
         local pi is constant:pi.
@@ -313,8 +312,6 @@
             nv:put("xfer/final", t2). }
 
         return 0. }).
-
-
 
     match:add("plan_corr", {    // build MANEUVER to enter Hohmann toward Targ
         //

--- a/pkg/memo.ks
+++ b/pkg/memo.ks
@@ -1,13 +1,13 @@
 @LAZYGLOBAL off.
-{
-    parameter memo is lex(). // memoization package
+{   parameter memo is lex(). // memoization package
 
     memo:add("getter", {    // memoize a getter (invariant during a phys tick)
         parameter getter.
         local memoized_time is 0.
         local memoized_value is 0.
-        return {
+        return {            // constructed delegate memoizing getter results
             if memoized_time<>time:seconds
                 set memoized_value to getter().
             set memoized_time to time:seconds.
-            return memoized_value. }. }). }
+            return memoized_value. }. }).
+}

--- a/pkg/mission.ks
+++ b/pkg/mission.ks
@@ -15,6 +15,7 @@
 
     mission:add("pname", {                      // return most recent mission phase label
         return nv:get("mission/phase/name", ""). }).
+
     mission:add("phase", {                      // return current mission phase number
         return max(0,min(plan:length-1,nv:get("mission/phase/number"))). }).
 
@@ -53,4 +54,5 @@
             local dt is task().
             if dt<=0 return false.
             set trigger_time to time:seconds + dt.
-            return true. } }). }
+            return true. } }).
+}

--- a/pkg/mnv.ks
+++ b/pkg/mnv.ks
@@ -34,7 +34,6 @@
     local e is constant:e.
     local G0 is constant:G0. // converion factor for Isp
 
-
     mnv:add("update_dv_at_t", {     // update maneuver for dv at time t
         parameter n.                // node to update.
         parameter dv.               // Body-rel change in velocity
@@ -191,5 +190,4 @@
         if F=0 or v_e=0 return 0.   // staging.
 
         return M0 * (1 - e^(-dV/v_e)) * v_e / F. }).
-
 }

--- a/pkg/nv.ks
+++ b/pkg/nv.ks
@@ -33,17 +33,17 @@
         f:clear().
         return f. }.
 
-    local nv_enc_t is lex().
-    nv_enc_t:add("Scalar", { parameter val. return val:tostring. }).
-    nv_enc_t:add("String", { parameter val. return quot+val. }).
-    nv_enc_t:add("Vessel", { parameter val. return "V"+val:name. }).
-    nv_enc_t:add("Body", { parameter val. return "B"+val:name. }).
+    local nv_enc_t is lex(                      // map type name to encoder
+        "Scalar", { parameter val. return val:tostring. },
+        "String", { parameter val. return quot+val. },
+        "Vessel", { parameter val. return "V"+val:name. },
+        "Body", { parameter val. return "B"+val:name. }).
 
-    function nv_enc { parameter val.
+    function nv_enc { parameter val.            // encode value for NV storage.
         local t is val:typename.
         return nv_enc_t[t](val). }
 
-    function nv_dec { parameter s.
+    function nv_dec { parameter s.              // decode value from NV storage.
         if s[0]=quot return s:remove(0,1).
         if s[0]="V" return vessel(s:remove(0,1)).
         if s[0]="B" return body(s:remove(0,1)).
@@ -88,4 +88,6 @@
 
     nv:add("clr", { parameter name.             // erase the named nonvolatile.
         nvram:remove(name).
-        if exists(name) deletepath(name). }). }
+        if exists(name) deletepath(name). }).
+
+}

--- a/pkg/phase.ks
+++ b/pkg/phase.ks
@@ -1,6 +1,6 @@
 @LAZYGLOBAL off.
-{
-    parameter phase is lex(). // stock mission phase library.
+{   parameter phase is lex(). // stock mission phase library.
+
     local nv is import("nv").
     local io is import("io").
     local ctrl is import("ctrl").
@@ -18,8 +18,7 @@
     function phase_unwarp {
         if kuniverse:timewarp:rate <= 1 return.
         kuniverse:timewarp:cancelwarp().
-        wait until kuniverse:timewarp:issettled.
-    }
+        wait until kuniverse:timewarp:issettled. }
 
     function phase_apowarp {
         if not kuniverse:timewarp:issettled return.
@@ -38,8 +37,7 @@
         kuniverse:timewarp:warpto(time:seconds+eta:apoapsis-45).
         wait 5.
         wait until kuniverse:timewarp:rate <= 1.
-        wait until kuniverse:timewarp:issettled.
-    }
+        wait until kuniverse:timewarp:issettled. }
 
     phase:add("countdown", {    // countdown, ignite, wait for thrust.
         if availablethrust>0 return 0.
@@ -91,8 +89,7 @@
             return cmd_steering:vector:normalized*speed_change_wanted. }).
 
         ctrl:dv(dv, 1, max_facing_error/2, max_facing_error).
-        return 5.
-    }).
+        return 5. }).
 
     phase:add("coast", {                // coast to near apoapsis
         if abort return 0.
@@ -159,8 +156,7 @@
 
         ctrl:dv(dv, 1, 1, max_facing_error).
 
-        return 5.
-    }).
+        return 5. }).
 
     local hold_in_pose is false.
     phase:add("hold", {
@@ -241,8 +237,7 @@
 
         ctrl:dv(dv, 1, 1, 5).
 
-        return 1.
-    }).
+        return 1. }).
 
     phase:add("aero", {
 
@@ -460,4 +455,5 @@
         // stage to discard dead weight and activate
         // any currently not-yet-ignited engines.
         stage.
-        return 1. }). }
+        return 1. }).
+}

--- a/pkg/predict.ks
+++ b/pkg/predict.ks
@@ -10,10 +10,12 @@
         parameter t is time:seconds.    // 1st parameter is time (default to now)
         parameter o is target.          // 2nd parameter is orbitable (default to target)
         return positionat(o, t) - body:position. }).
+
     predict:add("vel", {                // predict Body-relative Target velocity at time t
         parameter t is time:seconds.    // 1st parameter is time (default to now)
         parameter o is target.          // 2nd parameter is orbitable (default to target)
         return velocityat(o, t):orbit. }).
+
     predict:add("pos_err", {            // predict Target->Ship distance at time t
         parameter t is time:seconds.    // 1st parameter is time (default to now)
         parameter o is target.          // 2nd parameter is orbitable (default to target)
@@ -22,4 +24,5 @@
         local op is predict:pos(t, o).
         local pe is op-sp.
         return pe:mag. }).
+
 }

--- a/pkg/radar.ks
+++ b/pkg/radar.ks
@@ -25,4 +25,5 @@
         return a. }).
 
     radar:add("alt", {                                          // report altitude above calibration point
-        return round(alt:radar - radar:cal(), 3). }). }
+        return round(alt:radar - radar:cal(), 3). }).
+}

--- a/pkg/scan.ks
+++ b/pkg/scan.ks
@@ -1,7 +1,5 @@
 @LAZYGLOBAL off.
-
-{
-    parameter scan is lex(). // unidirectional hillclimb with backstep
+{   parameter scan is lex(). // unidirectional hillclimb with backstep
 
     // To use this:
     // - define fitness, a function of a state, to be maximized.
@@ -23,9 +21,9 @@
         return choose val if val:istype("Scalar") else val:copy(). }
 
     scan:add("init", {      // create the scanner state lexicon.
-        parameter fitness. // fitness function we will maximize
-        parameter fitincr. // function to increment the state vector
-        parameter fitfine. // function to reduce step size
+        parameter fitness.  // fitness function we will maximize
+        parameter fitincr.  // function to increment the state vector
+        parameter fitfine.  // function to reduce step size
         parameter fitstate. // state to provide to above.
 
         local c is list().
@@ -34,7 +32,7 @@
             "result", "fail",
             "failed", true ).
 
-        scanner:add("step", {
+        scanner:add("step", {       // the preconfigured scanner delegate we will return.
 
             // termination case 1: fitness says to stop searching.
             local score is fitness(fitstate).
@@ -54,8 +52,10 @@
                 local sc is c[1][0].
                 local il is sc - c[0][0].
                 local ir is sc - c[2][0].
+
                 if il<0 or ir<0
                     c:remove(0).    // not bracketing a maximum. make room for next.
+
                 else {              // bracketing a maximum.
                     // register the bracketed maximum as a reasonable result
                     set scanner:failed to false.
@@ -69,7 +69,7 @@
                     // keep only the old pre-max result,
                     // and set up to increment from it.
                     until c:length < 2 c:remove(1).
-                    set c[0][1] to copyof(fitstate). }}
+                    set c[0][1] to copyof(fitstate). } }
 
             // step to the next grid point for searching.
             set fitstate to fitincr(fitstate).

--- a/pkg/targ.ks
+++ b/pkg/targ.ks
@@ -9,35 +9,35 @@
 
     // TODO verify support for DockingPort as TARGET.
 
-    targ:add("parking_distance", 5).
+    targ:add("parking_distance", 5).            // distance from targ to parking
 
-    targ:add("targ_from_ship", {
+    targ:add("targ_from_ship", {                // vector to targ (from ship)
         if hastarget return target:position.
         if targ:target:hassuffix("position") return targ:target:position.
         if targ:orbit:hassuffix("position") return targ:orbit:position.
         return V(0,0,0). }).
 
-    targ:add("targ_vrel_ship", {
+    targ:add("targ_vrel_ship", {                // velocity of targ (relative to ship)
         local svo is ship:velocity:orbit.
         if hastarget return target:velocity:orbit - svo.
         if targ:target:hassuffix("velocity") return targ:target:velocity:orbit - svo.
         if targ:orbit:hassuffix("velocity") return targ:orbit:velocity:orbit - svo.
         return V(0,0,0). }).
 
-    targ:add("facing", {
+    targ:add("facing", {                        // facing of targ
         if hastarget return target:facing.
         if targ:target:hassuffix("facing") return targ:target:facing.
         // final fallback is to use ship facing if we do not have a target facing.
         return ship:facing. }).
 
-    targ:add("park_from_ship", {
+    targ:add("park_from_ship", {                // vector to parking (from ship)
         parameter d is targ:parking_distance.
         local p is targ:targ_from_ship().
         return p - p:normalized*targ:parking_distance. }).
 
-    local draw_parking_vecdraws is list().
+    local draw_parking_vecdraws is list().      // hold the vectors we drew
 
-    targ:add("draw_parking", {
+    targ:add("draw_parking", {                  // create the vectors showing parking
         local d is targ:parking_distance.
         local axes is list (
             V(1,0,0),V(-1,0,0),
@@ -57,14 +57,12 @@
         draw_parking_vecdraws:add(      // represent target as vector in target facing Z direction.
             vecdraw(targ:targ_from_ship, {
                 return targ:facing()*V(0,0,1)*5. }, RGB(0,1,1),
-                "", 1.0, true, 0.2, true, true)).
-
-        } ).
+                "", 1.0, true, 0.2, true, true)). } ).
 
     // targ:standoff(t) returns the predicted standoff target
     // at some specific universal time t, for use by long range
     // planning.
-    targ:add("standoff", {
+    targ:add("standoff", {                      // standoff position, for long range planning
         parameter t is time:seconds.
         local t_p is predict:pos(t, target).
         return t_p - t_p:normalized*targ:standoff_distance. }).
@@ -73,9 +71,9 @@
     targ:add("target", "").                     // mission target (for KSP TARGET) (or "" if not set)
     targ:add("orbit", "").                      // mission target Orbit (or "" if not set)
 
-    targ:add("standoff_distance", 100).          // default standoff distance (toward the body)
+    targ:add("standoff_distance", 100).         // default standoff distance
 
-    local function nameof { parameter x.
+    local function nameof { parameter x.        // return name of x using :name, or :tostring.
         return choose x:name if x:hassuffix("name") else x:tostring. }
 
     targ:add("load", {                          // set TARGET to mission target (or nothing)
@@ -108,16 +106,16 @@
             set targ:port to "". }              // remember selected is not a port.
 
         if sel:istype("Orbitable") {            // can specify with an Orbitable object.
-            set targ:orbitable to sel.             // remember the selected orbitable
+            set targ:orbitable to sel.          // remember the selected orbitable
             set sel to sel:orbit. }             // get its associated Orbit.
         else {
-            set targ:orbitable to "". }            // remember selected is not an orbitable.
+            set targ:orbitable to "". }         // remember selected is not an orbitable.
 
         if sel:istype("Orbit") {                // can specify with an Orbit object.
             set targ:orbit to sel.              // remember the selected orbit.
-            nv_put_orbit(sel). }                 // persist the orbital parameters.
+            nv_put_orbit(sel). }                // persist the orbital parameters.
         else {
-            set targ:orbit to "". }              // if we do not have an Orbit, clear the mission target.
+            set targ:orbit to "". }             // if we do not have an Orbit, clear the mission target.
 
         nv_put_name().
         nv_put_orbit().
@@ -147,7 +145,7 @@
         // if targ/name is persisted, set it as our mission target.
         // clear targ/name if it is a name of a thing that does not exist.
 
-        if nv:has("targ/name") {
+        if nv:has("targ/name") {                // try to pick target by name
             local n is nv:get("targ/name", "").
             set n to named(n).
             if n<>"" return targ:save(n).
@@ -203,17 +201,17 @@
 
     local map is create_map().
 
-    local function create_map {
+    local function create_map {                 // create map of names to targets.
         local m is lex(), l is list(), e is "".
         list targets in l. for e in l set m[e:name] to e.
         list bodies in l. for e in l set m[e:name] to e.
         list parts in l. for e in l if e:istype("DockingPort") set m[e:name] to e.
         return m. }
 
-    local function named { parameter n.
+    local function named { parameter n.         // get target with this name, or "" if there is not one.
         return choose map[n] if map:haskey(n) else "". }
 
-    local function nv_put_name {            // persist current mission target orbitable
+    local function nv_put_name {                // persist current mission target orbitable
         parameter name is targ:name.
         if name:hassuffix("name") set name to name:name.
         nv:put("targ/name", name). }
@@ -234,4 +232,6 @@
         else {
             nv:clr("targ"). } }
 
-    targ:restore(). }
+    // restore target from NV storage during import.
+    targ:restore().
+}

--- a/pkg/task.ks
+++ b/pkg/task.ks
@@ -19,8 +19,7 @@
     task:add("panel", task:gui:addvlayout()).
     task:add("list", list()).
 
-
-    function task_of {
+    function task_of {                          // create a "task" from these elements
         parameter text, cond, start, step, stop.
         assert(cond:istype("Delegate")).
         assert(start:istype("Delegate")).
@@ -29,15 +28,15 @@
         return lexicon("text", text, "cond", cond,
             "start", start, "step", step, "stop", stop).}
 
-    task:add("idle", task_of("Idle", always, nothing,
-        { lock throttle to 0. lock steering to facing. return 0. }, nothing)).
+    task:add("idle", task_of("Idle",            // the IDLE task, executes if nothing else does.
+        always, nothing, { lock throttle to 0. lock steering to facing. return 0. }, nothing)).
 
-    task:idle:add("pressed", always).
-    task:idle:add("unpress", always).
+    task:idle:add("pressed", always).           // backpatch "pressed" in idle to "always pressed"
+    task:idle:add("unpress", always).           // backpatch "unpress" in idle to "do nothing?
 
-    task:add("curr", task:idle).
+    task:add("curr", task:idle).                // make the idle task current
 
-    task:add("new", {
+    task:add("new", {                           // create a new task for a mission
         parameter text, cond, start, step, stop.
         assert(cond:istype("Delegate")).
         assert(start:istype("Delegate")).
@@ -49,27 +48,27 @@
         t:add("unpress", { set b:pressed to false. }).
         task:list:add(t). }).
 
-    task:add("pick", {
+    task:add("pick", {                          // pick a task to run
         for t in task:list
             if t:pressed() and t:cond()
                 return t.
         return task:idle. }).
 
-    task:add("step", {
+    task:add("step", {                          // run some task for one step
         local o is task:curr.
         local t is task:pick().
         if not(t=o) {
-            o:stop().
+            o:stop().                           // changing tasks, stop the old one.
             set task:curr to t.
             print "task: "+t:text.
-            t:start().
+            t:start().                          // changing tasks, start the new one.
         }
-        local dt is t:step().
-        if dt>0 return dt.
-        t:unpress().
+        local dt is t:step().                   // run a step
+        if dt>0 return dt.                      // positive return: want to do it again in a bit
+        t:unpress().                            // zero or negative: unpress the button, stop this task.
         return 1. }).
 
-    task:add("show", {
+    task:add("show", {                          // show the TASK GUI
         parameter x is 100.
         parameter y is 100.
         set task:gui:x to x.

--- a/pkg/term.ks
+++ b/pkg/term.ks
@@ -7,4 +7,5 @@
         set terminal:height to h.
         set terminal:width to w.
         if career():candoactions
-            core:doAction("open terminal", true). }). }
+            core:doAction("open terminal", true). }).
+}

--- a/pkg/visviva.ks
+++ b/pkg/visviva.ks
@@ -11,4 +11,5 @@
         parameter mu is body:mu.        // gravitational field strength
         local a is (rp+ra)/2.           // semi-major axis
         local v2 is mu*(2/r1 - 1/a).    // v^2/mu = 2/r1 - 1/a
-        return choose sqrt(v2) if v2>0 else 0. }). }
+        return choose sqrt(v2) if v2>0 else 0. }).
+}

--- a/std.ks
+++ b/std.ks
@@ -1,4 +1,5 @@
 @LAZYGLOBAL off.
+// Standard Library: GLOBAL things for FarKOS packages.
 
 local pkg is lex().
 


### PR DESCRIPTION
VS-Code "folding" looks best if the closing brace for a block is at the end of the last line (so it folds the whole block into just showing the first line).

If the brace is first on next line (after whitespace), the folding does not fold it,  making blocks fold to two lines when they could be just one.

This change pulls a bunch of braces up onto the prior line.